### PR TITLE
Display additional candidate context in tables and dropdowns for candidate_office_records page

### DIFF
--- a/what_the_fec/routes/candidate_office_records/endpoint_funcs.py
+++ b/what_the_fec/routes/candidate_office_records/endpoint_funcs.py
@@ -54,7 +54,7 @@ def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates)
 
     office_types_query = "SELECT id, name FROM office_types"
 
-    candidates_query = "SELECT id, email FROM candidates"
+    candidates_query = "SELECT * FROM candidates"
 
     party_types_query = "SELECT id, short_name FROM party_types"
 
@@ -82,6 +82,15 @@ def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates)
         .all()
     )
     columns_information = get_columns_information_dict(columns_information_result)
+    
+    candidates_email_dict = {}
+    for candidate in candidates:
+        candidates_email_dict[candidate["email"]] = {
+            "id": candidate["id"],
+            "first_name": candidate["first_name"],
+            "middle_name": candidate["middle_name"],
+            "last_name": candidate["last_name"],   
+        }
 
     dropdown_items_for_add = {
         "office_type": {
@@ -91,6 +100,7 @@ def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates)
         "candidate_email": {
             "data": candidates,
             "relevant_column_name": "email",
+            "data_dict": candidates_email_dict,
         },
         "party_type": {
             "data": party_types,

--- a/what_the_fec/routes/candidate_office_records/endpoint_funcs.py
+++ b/what_the_fec/routes/candidate_office_records/endpoint_funcs.py
@@ -13,6 +13,16 @@ from what_the_fec.routes.helpers import (
 logger: structlog.types.FilteringBoundLogger = structlog.get_logger(__name__)
 TABLE_NAME = "candidate_office_records"
 
+def get_candidates_email_dict(candidates):
+    candidates_email_dict = {}
+    for candidate in candidates:
+        candidates_email_dict[candidate["email"]] = {
+            "id": candidate["id"],
+            "first_name": candidate["first_name"],
+            "middle_name": candidate["middle_name"],
+            "last_name": candidate["last_name"],   
+        }
+    return candidates_email_dict
 
 def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates):
     candidate_office_records_query = f"""
@@ -83,14 +93,14 @@ def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates)
     )
     columns_information = get_columns_information_dict(columns_information_result)
     
-    candidates_email_dict = {}
-    for candidate in candidates:
-        candidates_email_dict[candidate["email"]] = {
-            "id": candidate["id"],
-            "first_name": candidate["first_name"],
-            "middle_name": candidate["middle_name"],
-            "last_name": candidate["last_name"],   
-        }
+    # candidates_email_dict = {}
+    # for candidate in candidates:
+    #     candidates_email_dict[candidate["email"]] = {
+    #         "id": candidate["id"],
+    #         "first_name": candidate["first_name"],
+    #         "middle_name": candidate["middle_name"],
+    #         "last_name": candidate["last_name"],   
+    #     }
 
     dropdown_items_for_add = {
         "office_type": {
@@ -100,7 +110,7 @@ def get_all_func(conn: Connection, request: Request, templates: Jinja2Templates)
         "candidate_email": {
             "data": candidates,
             "relevant_column_name": "email",
-            "data_dict": candidates_email_dict,
+            "data_dict": get_candidates_email_dict(candidates),
         },
         "party_type": {
             "data": party_types,
@@ -337,12 +347,13 @@ def update_single_page_func(
         .all()
     )
 
-    candidates_query = "SELECT id, email FROM candidates"
+    candidates_query = "SELECT * FROM candidates"
     candidates = conn.execute(text(candidates_query)).mappings().all()
     dropdown_items_for_add = {
         "candidate_email": {
             "data": candidates,
             "relevant_column_name": "email",
+            "data_dict": get_candidates_email_dict(candidates),
         },
     }
 
@@ -352,12 +363,7 @@ def update_single_page_func(
             "request": request,
             "items": candidate_office_records,
             "table_name": TABLE_NAME,
-            "dropdown_keys": [
-                "office_type",
-                "candidate_email",
-                "party_type",
-                "incumbent_challenger_status",
-            ],
+            "dropdown_keys": dropdown_items_for_add.keys(),
             "dropdown_items_for_add": dropdown_items_for_add,
         },
     )

--- a/what_the_fec/templates/candidate_office_records/update.j2
+++ b/what_the_fec/templates/candidate_office_records/update.j2
@@ -20,7 +20,21 @@
                 <select name="candidate_email" id="candidate_email">
                     {% for entries in dropdown_items_for_add["candidate_email"]["data"] %}
                         <option value="{{entries[dropdown_items_for_add['candidate_email']['relevant_column_name']]}}">
-                            {{entries[dropdown_items_for_add['candidate_email']['relevant_column_name']]}}
+
+
+                            {% set candidate_email = entries[dropdown_items_for_add["candidate_email"]['relevant_column_name']] %}
+                            {% if candidate_email is none %}
+                                NULL
+                            {% else %}
+                                {{candidate_email}}
+                            {% endif %}
+
+
+                            {% set candidate_dict_entry = dropdown_items_for_add["candidate_email"]["data_dict"][candidate_email] %}
+                            {% with candidate_dict_entry=candidate_dict_entry %}
+                                {% include '/includes/candidate_email_helper.html' %}
+                            {% endwith %}
+
                         </option>
                     {% endfor %}
                     <option value="NULL">NULL</option>

--- a/what_the_fec/templates/includes/candidate_email_helper.html
+++ b/what_the_fec/templates/includes/candidate_email_helper.html
@@ -1,0 +1,21 @@
+{% set candidate_id = candidate_dict_entry["id"] %} 
+{% set candidate_last_name = candidate_dict_entry["last_name"] %}
+{% set candidate_first_name = candidate_dict_entry["first_name"] %} 
+{% set candidate_middle_name = candidate_dict_entry["middle_name"] %}
+ (candidates ID {{candidate_dict_entry["id"]}}: 
+{% if candidate_last_name is none %}
+    NULL
+{% else %}
+    {{candidate_last_name}}
+{% endif %}
+, 
+{% if candidate_first_name is none %}
+    NULL
+{% else %}
+    {{candidate_first_name}}
+{% endif %}
+{% if candidate_middle_name is none %}
+    NULL
+{% else %}
+    {{candidate_middle_name}}
+{% endif %})

--- a/what_the_fec/templates/includes/insert_fieldset.html
+++ b/what_the_fec/templates/includes/insert_fieldset.html
@@ -64,9 +64,29 @@
                     <label> {{key}} </label>
                     <select name="{{key}}" id="{{key}}">
                         {% for entries in dropdown_items_for_add[key]["data"] %}
-                            <option value="{{entries[dropdown_items_for_add[key]['relevant_column_name']]}}">
-                                {{entries[dropdown_items_for_add[key]['relevant_column_name']]}}
-                            </option>
+                            {% if key == "candidate_email"%}
+                                <option value="{{entries[dropdown_items_for_add[key]['relevant_column_name']]}}">
+
+                                    {% set candidate_email = entries[dropdown_items_for_add[key]['relevant_column_name']] %}
+                                    {% if candidate_email is none %}
+                                        NULL
+                                    {% else %}
+                                        {{candidate_email}}
+                                    {% endif %}
+
+
+                                    {% set candidate_dict_entry = dropdown_items_for_add["candidate_email"]["data_dict"][entries[dropdown_items_for_add[key]['relevant_column_name']]] %}
+                                    {% with candidate_dict_entry=candidate_dict_entry %}
+                                        {% include '/includes/candidate_email_helper.html' %}
+                                    {% endwith %}
+
+
+                                </option>
+                            {% else %}
+                                <option value="{{entries[dropdown_items_for_add[key]['relevant_column_name']]}}">
+                                    {{entries[dropdown_items_for_add[key]['relevant_column_name']]}}
+                                </option>
+                            {% endif %}
                         {% endfor %}
                             {% if key == "candidate_email"%}
                                 <option value="NULL">NULL</option>

--- a/what_the_fec/templates/includes/read_table.html
+++ b/what_the_fec/templates/includes/read_table.html
@@ -10,7 +10,11 @@
                 <th></th>
             {% endif %}
             {% for key in items[0].keys() %}
-                <th>{{ key }}</th>
+                {% if key == "candidate_email" %}
+                    <th>{{ key }} (<a href="/candidates"><em>candidates</em></a> information in parentheses)</th>
+                {% else %}
+                    <th>{{ key }}</th>
+                {% endif %}
             {% endfor %}
         </tr>
         <tbody>
@@ -27,7 +31,17 @@
                 {% if item[key] is none %}
                     <td>NULL</td>
                 {% else %}
-                    <td>{{item[key]}}</td>
+                    {% if key == "candidate_email" %}
+                        <td>
+                            {{item[key]}} 
+                            {% set candidate_dict_entry = dropdown_items_for_add["candidate_email"]["data_dict"][item[key]] %}
+                            {% with candidate_dict_entry=candidate_dict_entry %}
+                                {% include '/includes/candidate_email_helper.html' %}
+                            {% endwith %}
+                        </td>
+                    {% else %}
+                        <td>{{item[key]}}</td>
+                    {% endif %}
                 {% endif %}
             {% endfor %}
 


### PR DESCRIPTION
- Display additional candidate context (ID, last name, first name, middle name) in tables and dropdowns for candidate_office_records page
- No changes to backend DML queries need to be made

Screenshots from candidate_office_records page
<img width="501" alt="Screenshot 2023-06-09 at 5 01 32 PM" src="https://github.com/nolandseigler/osu-cs340-project/assets/21234456/f2f48753-8e92-4239-98ea-a0d849b85540">
<img width="502" alt="Screenshot 2023-06-09 at 5 01 22 PM" src="https://github.com/nolandseigler/osu-cs340-project/assets/21234456/2b2035fd-b970-4854-b6aa-0f14823935d2">
